### PR TITLE
Add addon/index.js so we can easily import StateManager and State in an ember-cli app.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,5 @@
+import StateManager from './state-manager';
+import State from './state';
+
+export default StateManager;
+export {StateManager, State};


### PR DESCRIPTION
This solution was proposed by @ink-spot in https://github.com/emberjs/ember-states/issues/18. 
